### PR TITLE
Added dummy example tool snap-to-network

### DIFF
--- a/lib/galaxy/config/sample/tool_conf.xml.sample
+++ b/lib/galaxy/config/sample/tool_conf.xml.sample
@@ -1,5 +1,8 @@
 <?xml version='1.0' encoding='utf-8'?>
 <toolbox monitor="true">
+  <section name="OGC Services" id="ogc_service">
+    <tool file="../tools/ogc_services/snap_to_network.xml" />
+  </section>
   <section id="getext" name="Get Data">
     <tool file="data_source/upload.xml" />
     <tool file="data_source/ucsc_tablebrowser.xml" />

--- a/tools/ogc_services/snap_to_network.xml
+++ b/tools/ogc_services/snap_to_network.xml
@@ -7,7 +7,7 @@
         <requirement type="package">geojson</requirement>
     </requirements>
     <command><![CDATA[
-        python $__tool_directory__/wrap_snap_to_network.py --ogc_service_url $ogc_service_url --coordinate_geojson "$coordinate_geojson" --coordinate_csv "$coordinate_csv" --distance $distance --method $method --accumulation $accumulation --output $galaxy_output
+        python $__tool_directory__/wrap_snap_to_network.py --ogc_service_url $ogc_service_url --coordinate_geojson "$coordinate_geojson" --coordinate_csv "$coordinate_csv" --distance $distance --method $method --accumulation $accumulation --basin_id "$basin_id" --output $galaxy_output
     ]]></command>
     <inputs>
         <param name="coordinate_geojson" type="text" value='{"coordinates":[[-17.25355, -44.885825], [-13.763611, -43.595833]], "type": "MultiPoint"}' area="true" label="Coordinates as GeoJSON Multipoint"></param>
@@ -17,6 +17,10 @@
             <option value="distance">Distance</option>
             <option value="accumulation">Accumulation</option>
             <option value="both">Both</option>
+        </param>
+        <param name="basin_id" type="select" label="Which basin...">
+            <option value="481051">Basin Sao Francisco (I think)</option>
+            <option value="Other">No other basin right now</option>
         </param>
         <param name="distance" type="integer" label="Maximum radius in map pixels." value="500"></param>
         <param name="accumulation" type="float" label="Minimum flow accumulation." value="0.5"></param>

--- a/tools/ogc_services/snap_to_network.xml
+++ b/tools/ogc_services/snap_to_network.xml
@@ -7,10 +7,11 @@
         <requirement type="package">geojson</requirement>
     </requirements>
     <command><![CDATA[
-        python /home/mbuurman/galaxy/galaxy/tools/ogc_services/wrap_snap_to_network.py --coordinate_geojson "$coordinate_geojson" --coordinate_csv "$coordinate_csv" --distance $distance --method $method --accumulation $accumulation --output $galaxy_output
+        python /home/mbuurman/galaxy/galaxy/tools/ogc_services/wrap_snap_to_network.py --ogc_service_url $ogc_service_url --coordinate_geojson "$coordinate_geojson" --coordinate_csv "$coordinate_csv" --distance $distance --method $method --accumulation $accumulation --output $galaxy_output
     ]]></command>
     <inputs>
         <param name="coordinate_geojson" type="text" value='{"coordinates":[[-17.25355, -44.885825], [-13.763611, -43.595833]], "type": "MultiPoint"}' area="true" label="Coordinates as GeoJSON Multipoint"></param>
+        <param name="ogc_service_url" type="text" label="Which URL to call, including port." value="http://localhost:5000"></param>
         <param name="coordinate_csv" type="text" value="-17.25355, -44.885825&#10;-13.763611, -43.595833" area="true" label="Coordinates as csv"></param>
         <param name="method" type="select" label="Which method to use for snapping:">
             <option value="distance">Distance</option>

--- a/tools/ogc_services/snap_to_network.xml
+++ b/tools/ogc_services/snap_to_network.xml
@@ -7,7 +7,7 @@
         <requirement type="package">geojson</requirement>
     </requirements>
     <command><![CDATA[
-        python /home/mbuurman/galaxy/galaxy/tools/ogc_services/wrap_snap_to_network.py --ogc_service_url $ogc_service_url --coordinate_geojson "$coordinate_geojson" --coordinate_csv "$coordinate_csv" --distance $distance --method $method --accumulation $accumulation --output $galaxy_output
+        python $__tool_directory__/wrap_snap_to_network.py --ogc_service_url $ogc_service_url --coordinate_geojson "$coordinate_geojson" --coordinate_csv "$coordinate_csv" --distance $distance --method $method --accumulation $accumulation --output $galaxy_output
     ]]></command>
     <inputs>
         <param name="coordinate_geojson" type="text" value='{"coordinates":[[-17.25355, -44.885825], [-13.763611, -43.595833]], "type": "MultiPoint"}' area="true" label="Coordinates as GeoJSON Multipoint"></param>

--- a/tools/ogc_services/snap_to_network.xml
+++ b/tools/ogc_services/snap_to_network.xml
@@ -1,4 +1,4 @@
-<tool id="snap_to_network" name="Snap to network (py)" version="0.1.0">
+<tool id="snap_to_network" name="Snap to network" version="0.1.0">
     <description>Snaps point coordinates to a network.</description>
     <stdio>
         <exit_code range="1:" />
@@ -11,7 +11,7 @@
     ]]></command>
     <inputs>
         <param name="coordinate_geojson" type="text" value='{"coordinates":[[-17.25355, -44.885825], [-13.763611, -43.595833]], "type": "MultiPoint"}' area="true" label="Coordinates as GeoJSON Multipoint"></param>
-        <param name="ogc_service_url" type="text" label="Which URL to call, including port." value="http://localhost:5000"></param>
+        <param name="ogc_service_url" type="text" label="OGC API: Which URL to request, including port." value="http://localhost:5000"></param>
         <param name="coordinate_csv" type="text" value="-17.25355, -44.885825&#10;-13.763611, -43.595833" area="true" label="Coordinates as csv"></param>
         <param name="method" type="select" label="Which method to use for snapping:">
             <option value="distance">Distance</option>
@@ -30,7 +30,7 @@
         </test>
     </tests>
     <help><![CDATA[
-        Snapping to some stream network using GRASS via hydrographr's snap-to-network.
+        Snap point data to some stream network using GRASS via hydrographr's snap-to-network.
     ]]></help>
     <citations>
         <citation type="bibtex">

--- a/tools/ogc_services/snap_to_network.xml
+++ b/tools/ogc_services/snap_to_network.xml
@@ -1,0 +1,45 @@
+<tool id="snap_to_network" name="Snap to network (py)" version="0.1.0">
+    <description>Snaps point coordinates to a network.</description>
+    <stdio>
+        <exit_code range="1:" />
+    </stdio>
+    <requirements>
+        <requirement type="package">geojson</requirement>
+    </requirements>
+    <command><![CDATA[
+        python /home/mbuurman/galaxy/galaxy/tools/ogc_services/wrap_snap_to_network.py --coordinate_geojson "$coordinate_geojson" --coordinate_csv "$coordinate_csv" --distance $distance --method $method --accumulation $accumulation --output $galaxy_output
+    ]]></command>
+    <inputs>
+        <param name="coordinate_geojson" type="text" value='{"coordinates":[[-17.25355, -44.885825], [-13.763611, -43.595833]], "type": "MultiPoint"}' area="true" label="Coordinates as GeoJSON Multipoint"></param>
+        <param name="coordinate_csv" type="text" value="-17.25355, -44.885825&#10;-13.763611, -43.595833" area="true" label="Coordinates as csv"></param>
+        <param name="method" type="select" label="Which method to use for snapping:">
+            <option value="distance">Distance</option>
+            <option value="accumulation">Accumulation</option>
+            <option value="both">Both</option>
+        </param>
+        <param name="distance" type="integer" label="Maximum radius in map pixels." value="500"></param>
+        <param name="accumulation" type="float" label="Minimum flow accumulation." value="0.5"></param>
+    </inputs>
+    <outputs>
+        <data name="galaxy_output" format="geojson" />
+    </outputs>
+    <tests>
+        <test>
+            <!--<output name="galaxy_output" file="/galaxy/tools/mytools/test_data/test_output.txt"/>-->
+        </test>
+    </tests>
+    <help><![CDATA[
+        Snapping to some stream network using GRASS via hydrographr's snap-to-network.
+    ]]></help>
+    <citations>
+        <citation type="bibtex">
+            @Manual{,
+                title = {httr2: Perform HTTP Requests and Process the Responses},
+                author = {Hadley Wickham},
+                year = {2023},
+                note = {R package version 0.2.3},
+                url = {https://CRAN.R-project.org/package=httr2},
+            }
+        </citation>
+    </citations>
+</tool>

--- a/tools/ogc_services/wrap_snap_to_network.py
+++ b/tools/ogc_services/wrap_snap_to_network.py
@@ -95,6 +95,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(
                         prog='Calling snap-to-network service from OGC API at localhost:5000 via python',
                         description='This program wants to substitute snap_to_network.R, see https://glowabio.github.io/hydrographr/reference/snap_to_network.html')
+    parser.add_argument('--ogc_service_url', default="http://localhost:500", help='Which service to call, incl. http/https and port, e.g. http://localhost:5000')
     parser.add_argument('--method', default="distance", help='"distance", "accumulation", or "both". Defines if the points are snapped using the distance or flow accumulation.')
     parser.add_argument('--distance', default=500, help='Maximum radius in map pixels. The points will be snapped to the next stream within this radius.')
     parser.add_argument('--accumulation', default=0.5, help='Minimum flow accumulation. Points will be snapped to the next stream with a flow accumulation equal or higher than the given value.')
@@ -129,7 +130,7 @@ if __name__ == '__main__':
 
     ### Assemble the HTTP request
     LOGGER.debug('Assembling the request...')
-    url = 'http://localhost:5000/processes/snap-to-network/execution'
+    url = args.ogc_service_url.rstrip('/')+'/processes/snap-to-network/execution'
     LOGGER.info('This URL will be queried: %s' % url)
     h = {'accept': 'application/json', 'Content-Type': 'application/json'}
     body = {
@@ -146,6 +147,7 @@ if __name__ == '__main__':
 
     ### Make POST request
     LOGGER.debug('Making POST request to server:')
+    print('Making POST request to server:')
     resp = requests.post(url, headers=h, json=body)
     resp_json = resp.json()
     LOGGER.info('Finished making POST request to server! Received HTTP status code: %s' % resp.status_code)

--- a/tools/ogc_services/wrap_snap_to_network.py
+++ b/tools/ogc_services/wrap_snap_to_network.py
@@ -98,6 +98,7 @@ if __name__ == '__main__':
     parser.add_argument('--output', default="DUMMY", help='Galaxy needs this, but you can just put some dummy string there.')
     parser.add_argument('--coordinate_geojson', default="null", help='GeoJSON Coordinates in which CRS?')
     parser.add_argument('--coordinate_csv', default="null", help='Columns with coordinates in which CRS?')
+    parser.add_argument('--basin_id', default="481051", help='The number of the basin in which to look for species occurences.')
     args = parser.parse_args()
     LOGGER.debug('Getting the input parameters... done.')
 
@@ -135,6 +136,7 @@ if __name__ == '__main__':
             "method" : args.method,
             "distance" : args.distance,
             "accumulation" : args.accumulation,
+            "basin_id": args.basin_id,
             "coordinate_multipoint" : multipoint_to_pass_on
         }
     }

--- a/tools/ogc_services/wrap_snap_to_network.py
+++ b/tools/ogc_services/wrap_snap_to_network.py
@@ -75,7 +75,7 @@ if __name__ == '__main__':
 
     print('Python script: %s' % sys.argv[0])
 
-    logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+    logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
 
     ### Replace those weird escaped characters from the string that was passed by Galaxy GUI:
     LOGGER.debug('Python script inputs sys.argv: %s' % sys.argv)
@@ -96,7 +96,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(
                         prog='Calling snap-to-network service from OGC API at localhost:5000 via python',
                         description='This program wants to substitute snap_to_network.R, see https://glowabio.github.io/hydrographr/reference/snap_to_network.html')
-    parser.add_argument('--ogc_service_url', default="http://localhost:500", help='Which service to call, incl. http/https and port, e.g. http://localhost:5000')
+    parser.add_argument('--ogc_service_url', default="http://localhost:5000", help='Which service to call, incl. http/https and port, e.g. http://localhost:5000')
     parser.add_argument('--method', default="distance", help='"distance", "accumulation", or "both". Defines if the points are snapped using the distance or flow accumulation.')
     parser.add_argument('--distance', default=500, help='Maximum radius in map pixels. The points will be snapped to the next stream within this radius.')
     parser.add_argument('--accumulation', default=0.5, help='Minimum flow accumulation. Points will be snapped to the next stream with a flow accumulation equal or higher than the given value.')
@@ -120,6 +120,7 @@ if __name__ == '__main__':
     else:
         if len(args.coordinate_csv) == 0:
             LOGGER.info('Using GeoJSON coordinates! %s' % type(args.coordinate_geojson))
+            LOGGER.debug('These are the coordinates that were passed: %s' % args.coordinate_geojson)
             multipoint_to_pass_on = geojson.loads(args.coordinate_geojson)
             LOGGER.debug('Parsed the string geojson to proper geojson object')
         else:

--- a/tools/ogc_services/wrap_snap_to_network.py
+++ b/tools/ogc_services/wrap_snap_to_network.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+
+import requests
+import argparse
+import sys
+import geojson
+import logging
+
+LOGGER = logging.getLogger(__name__)
+
+
+'''
+10 Oktober 2023
+
+Calling this script:
+python /home/mbuurman/galaxy/galaxy/tools/ogc_services/wrap_snap_to_network.py --method "distance" --distance 500 --accumulation 0.5 --coordinate_geojson "{\"inputs\":{\"method\": \"distance\", \"accumulation\": 0.5, \"distance\": 500, \"coordinate_multipoint\":{\"coordinates\": [[-17.25355, -44.885825], [-13.763611, -43.595833]], \"type\": \"MultiPoint\"}}}" 
+
+How Galaxy calls this script:
+python /home/mbuurman/galaxy/galaxy/tools/ogc_services/wrap_snap_to_network.py --coordinate_geojson "$coordinate_geojson" --coordinate_csv "$coordinate_csv" --distance $distance --method $method --accumulation $accumulation --output $galaxy_output
+
+This script is a wrapper to be called by Galaxy.
+It then makes a HTTP request to a OGC service.
+
+NOTE:
+THe OGC service wants the GeoJSON in the parameter named coordinate_multipoint, while this wrapper takes coordinate_geojson or coordinate_csv, to distinguish between both types!
+
+These are the valid inputs for the OGC service:
+body = {
+    "inputs":{
+        "method": "distance",
+        "distance": 500,
+        "accumulation": 0.5,
+        "coordinate_multipoint": {
+           "type": "MultiPoint",
+           "coordinates": [
+                [-17.25355, -44.885825],
+                [-13.763611, -43.595833]
+            ]
+        }
+    }
+}
+
+These are the inputs without newlines and with escaped double-quotes (ready for curl):
+{\"inputs\":{\"method\":\"distance\",\"distance\":500,\"accumulation\":0.5,\"coordinate_multipoint\":{\"type\":\"MultiPoint\",\"coordinates\":[[-17.25355, -44.885825], [-13.763611, -43.595833]]}}}
+
+How to pass the inputs?
+curl -X POST "http://localhost:5000/processes/snap-to-network/execution" -H "Content-Type: application/json" -d "{\"inputs\":{\"method\":\"distance\",\"distance\":500,\"accumulation\":0.5,\"coordinate_multipoint\":{\"type\":\"MultiPoint\",\"coordinates\":[[-17.25355, -44.885825], [-13.763611, -43.595833]]}}}"
+'''
+
+
+
+def csv_to_geojson(input_string, sep=','):
+    result_multipoint = {"type": "MultiPoint", "coordinates":[]}
+
+    # Split at newline:
+    # If there is a newline in the GUI, it will end up here as "__cn__":
+    LOGGER.debug('CSV input before splitting: %s' % input_string)
+    input_string = input_string.split('__cn__')
+    LOGGER.debug('CSV input after splitting: %s' % input_string)
+
+    # Get coords from each line:
+    for line in input_string:
+        LOGGER.debug('Found coordinate line: %s' % line)
+        splitted = line.strip().split(sep)
+        coord1, coord2 = float(splitted[0].strip()), float(splitted[1].strip())
+        LOGGER.debug('Extracted these coordinates %s, %s' % (coord1, coord2))
+        result_multipoint['coordinates'].append([coord2, coord1])
+    
+    LOGGER.info('Finished creating GeoJSON multipoint from CSV coordinates: %s' % geojson.dumps(result_multipoint))
+    return result_multipoint
+
+
+
+if __name__ == '__main__':
+
+    print('Python script: %s' % sys.argv[0])
+
+    logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+
+    ### Replace those weird escaped characters from the string that was passed by Galaxy GUI:
+    LOGGER.debug('Python script inputs sys.argv: %s' % sys.argv)
+    LOGGER.debug('Run the replacement dirty fix:')
+    i = 0
+    for i in range(0,len(sys.argv)):
+        LOGGER.debug('Python command line arg: "%s"' % sys.argv[i])
+        sys.argv[i] = sys.argv[i].replace('__oc__', '{').replace('__cc__', '}')
+        sys.argv[i] = sys.argv[i].replace('__ob__', '[').replace('__cb__', ']')
+        sys.argv[i] = sys.argv[i].replace('__dq__', '"')
+        LOGGER.debug('Same item after replace: "%s"' % sys.argv[i])
+        # https://git.bwcloud.uni-freiburg.de/galaxyproject/galaxy/-/blob/5701fe7e108126fda05c33dfe083bd2c7f370db9/tools/filters/grep.py#L71
+
+
+    ### Input params
+    LOGGER.debug('Getting the input parameters...')
+    parser = argparse.ArgumentParser(
+                        prog='Calling snap-to-network service from OGC API at localhost:5000 via python',
+                        description='This program wants to substitute snap_to_network.R, see https://glowabio.github.io/hydrographr/reference/snap_to_network.html')
+    parser.add_argument('--method', default="distance", help='"distance", "accumulation", or "both". Defines if the points are snapped using the distance or flow accumulation.')
+    parser.add_argument('--distance', default=500, help='Maximum radius in map pixels. The points will be snapped to the next stream within this radius.')
+    parser.add_argument('--accumulation', default=0.5, help='Minimum flow accumulation. Points will be snapped to the next stream with a flow accumulation equal or higher than the given value.')
+    parser.add_argument('--output', default="DUMMY", help='Galaxy needs this, but you can just put some dummy string there.')
+    parser.add_argument('--coordinate_geojson', default="null", help='GeoJSON Coordinates in which CRS?')
+    parser.add_argument('--coordinate_csv', default="null", help='Columns with coordinates in which CRS?')
+    args = parser.parse_args()
+    LOGGER.debug('Getting the input parameters... done.')
+
+
+    ### Select whether we have CSV or GeoJSON coordinates, parse accordingly:
+    if len(args.coordinate_geojson) == 0:
+        if len(args.coordinate_csv) == 0:
+            err_msg = 'Cannot have both coordinate fields empty! Please pass either a CSV list or a GeoJSON multipoint.'
+            LOGGER.error(err_msg)
+            raise ValueError(err_msg)
+        else:
+            LOGGER.info('Using CSV coordinates: "%s"' % args.coordinate_csv)
+            multipoint_to_pass_on = csv_to_geojson(args.coordinate_csv)
+            LOGGER.debug('Converted the CSV coordinates to multipoint in geojson')
+    else:
+        if len(args.coordinate_csv) == 0:
+            LOGGER.info('Using GeoJSON coordinates! %s' % type(args.coordinate_geojson))
+            multipoint_to_pass_on = geojson.loads(args.coordinate_geojson)
+            LOGGER.debug('Parsed the string geojson to proper geojson object')
+        else:
+            LOGGER.warning('If both coordinate input fields are filled, we use the CSV ones!')
+            LOGGER.info('Using CSV coordinates: "%s"' % args.coordinate_csv)
+            multipoint_to_pass_on = csv_to_geojson(args.coordinate_csv)
+            LOGGER.debug('Converted the CSV coordinates to multipoint in geojson')
+
+
+    ### Assemble the HTTP request
+    LOGGER.debug('Assembling the request...')
+    url = 'http://localhost:5000/processes/snap-to-network/execution'
+    LOGGER.info('This URL will be queried: %s' % url)
+    h = {'accept': 'application/json', 'Content-Type': 'application/json'}
+    body = {
+        "inputs":{
+            "method" : args.method,
+            "distance" : args.distance,
+            "accumulation" : args.accumulation,
+            "coordinate_multipoint" : multipoint_to_pass_on
+        }
+    }
+    LOGGER.info('This is the request body: %s' % body)
+    LOGGER.debug('Data type of body: %s' % type(body))
+
+
+    ### Make POST request
+    LOGGER.debug('Making POST request to server:')
+    resp = requests.post(url, headers=h, json=body)
+    resp_json = resp.json()
+    LOGGER.info('Finished making POST request to server! Received HTTP status code: %s' % resp.status_code)
+    LOGGER.info('And this is the server\'s response: \n%s' % resp_json)
+    # Example: {'id': 'snapped_points', 'value': {'type': 'MultiPoint', 'coordinates': [['-43.595833', '-13.763611'], ['-44.885825', '-17.25355']]}}
+
+
+    ### Hand through server errors:
+    if not resp.status_code == 200:
+        err_msg = 'Tool failure! Server responded with HTTP status code %s (expected 200)' % resp.status_code
+        LOGGER.error(err_msg)
+        raise ValueError(err_msg)
+    elif (('code' in resp_json and resp_json['code'] == 'InvalidParameterValue') 
+       or ('description' in resp_json and resp_json['description'] == 'Error updating job')):
+        err_msg = 'Tool failure! Server responded with: %s' % resp_json
+        LOGGER.error(err_msg)
+        raise ValueError(err_msg)
+
+
+    ### Write to file
+    OUTPUTFILE = args.output
+    with open(OUTPUTFILE, 'w') as out:
+        geojson.dump(resp_json, out)
+        LOGGER.info('Written to file: %s' % OUTPUTFILE)

--- a/tools/ogc_services/wrap_snap_to_network.py
+++ b/tools/ogc_services/wrap_snap_to_network.py
@@ -10,22 +10,20 @@ LOGGER = logging.getLogger(__name__)
 
 
 '''
-10 Oktober 2023
+Merret, 10 Oktober 2023
 
 Calling this script:
 python /home/mbuurman/galaxy/galaxy/tools/ogc_services/wrap_snap_to_network.py --method "distance" --distance 500 --accumulation 0.5 --coordinate_geojson "{\"inputs\":{\"method\": \"distance\", \"accumulation\": 0.5, \"distance\": 500, \"coordinate_multipoint\":{\"coordinates\": [[-17.25355, -44.885825], [-13.763611, -43.595833]], \"type\": \"MultiPoint\"}}}" 
-
-How Galaxy calls this script:
-python /home/mbuurman/galaxy/galaxy/tools/ogc_services/wrap_snap_to_network.py --coordinate_geojson "$coordinate_geojson" --coordinate_csv "$coordinate_csv" --distance $distance --method $method --accumulation $accumulation --output $galaxy_output
 
 This script is a wrapper to be called by Galaxy.
 It then makes a HTTP request to a OGC service.
 
 NOTE:
-THe OGC service wants the GeoJSON in the parameter named coordinate_multipoint, while this wrapper takes coordinate_geojson or coordinate_csv, to distinguish between both types!
+The OGC service wants the inputs as GeoJSON in the parameter named "coordinate_multipoint",
+while this wrapper takes "coordinate_geojson" or "coordinate_csv", to distinguish between both types!
 
 These are the valid inputs for the OGC service:
-body = {
+{
     "inputs":{
         "method": "distance",
         "distance": 500,
@@ -33,18 +31,15 @@ body = {
         "coordinate_multipoint": {
            "type": "MultiPoint",
            "coordinates": [
-                [-17.25355, -44.885825],
-                [-13.763611, -43.595833]
+                [-44.885825, -17.25355],
+                [-43.595833, -13.763611]
             ]
         }
     }
 }
 
-These are the inputs without newlines and with escaped double-quotes (ready for curl):
-{\"inputs\":{\"method\":\"distance\",\"distance\":500,\"accumulation\":0.5,\"coordinate_multipoint\":{\"type\":\"MultiPoint\",\"coordinates\":[[-17.25355, -44.885825], [-13.763611, -43.595833]]}}}
-
-How to pass the inputs?
-curl -X POST "http://localhost:5000/processes/snap-to-network/execution" -H "Content-Type: application/json" -d "{\"inputs\":{\"method\":\"distance\",\"distance\":500,\"accumulation\":0.5,\"coordinate_multipoint\":{\"type\":\"MultiPoint\",\"coordinates\":[[-17.25355, -44.885825], [-13.763611, -43.595833]]}}}"
+How to call the pygeoapi service that this script calls?
+curl -X POST "http://localhost:5000/processes/snap-to-network/execution" -H "Content-Type: application/json" -d "{\"inputs\":{\"method\":\"distance\",\"distance\":500,\"accumulation\":0.5,\"coordinate_multipoint\":{\"type\":\"MultiPoint\",\"coordinates\":[[-44.885825, -17.25355], [-43.595833, -13.763611]]}}}"
 '''
 
 
@@ -154,7 +149,6 @@ if __name__ == '__main__':
     resp_json = resp.json()
     LOGGER.info('Finished making POST request to server! Received HTTP status code: %s' % resp.status_code)
     LOGGER.info('And this is the server\'s response: \n%s' % resp_json)
-    # Example: {'id': 'snapped_points', 'value': {'type': 'MultiPoint', 'coordinates': [['-43.595833', '-13.763611'], ['-44.885825', '-17.25355']]}}
 
 
     ### Hand through server errors:
@@ -173,4 +167,4 @@ if __name__ == '__main__':
     OUTPUTFILE = args.output
     with open(OUTPUTFILE, 'w') as out:
         geojson.dump(resp_json, out)
-        LOGGER.info('Written to file: %s' % OUTPUTFILE)
+        LOGGER.info('Output written to file: %s' % OUTPUTFILE)

--- a/tools/ogc_services/wrap_snap_to_network.py
+++ b/tools/ogc_services/wrap_snap_to_network.py
@@ -86,6 +86,7 @@ if __name__ == '__main__':
         sys.argv[i] = sys.argv[i].replace('__oc__', '{').replace('__cc__', '}')
         sys.argv[i] = sys.argv[i].replace('__ob__', '[').replace('__cb__', ']')
         sys.argv[i] = sys.argv[i].replace('__dq__', '"')
+        sys.argv[i] = sys.argv[i].replace('__cn__', '')
         LOGGER.debug('Same item after replace: "%s"' % sys.argv[i])
         # https://git.bwcloud.uni-freiburg.de/galaxyproject/galaxy/-/blob/5701fe7e108126fda05c33dfe083bd2c7f370db9/tools/filters/grep.py#L71
 


### PR DESCRIPTION
What I did: I added a tool (config xml and python code) that calls an OGC API service. So the main processing takes place on the server that exposes an OGC API which is called by this galaxy tool.
Why: This tool will be useful for the AquaInfra galaxy instance. So far, this is dummy and only for testing.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Deploy an instance of pygeoapi locally on localhost:5000, or have an URL of a pygeoapi server ready which runs the snap-to-network OGC service.
  2. Run the galaxy tool snap-to-network with the given default input values.
  3. It should return the following GeoJON: `{"id": "snapped_points", "value": {"type": "MultiPoint", "coordinates": [["-43.595833", "-13.763611"], ["-44.885825", "-17.25355"]]}}`

## License
- [] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). - THIS IS JUST A TEST COMMIT.
