### PR TITLE
Added example tool get_species_data that calls ogc service.

### DIFF
--- a/lib/galaxy/config/sample/tool_conf.xml.sample
+++ b/lib/galaxy/config/sample/tool_conf.xml.sample
@@ -128,6 +128,9 @@
     <tool file="phenotype_association/ldtools.xml" />
     <tool file="phenotype_association/master2pg.xml" />
   </section>
+  <section name="OGC Services" id="ogc_service">
+    <tool file="../tools/ogc_services/get_species_data.xml" />
+  </section>
   <!--
   <section id="interactivetools" name="Interactive tools">
     <tool file="interactive/codingSnps.xml" />

--- a/tools/ogc_services/get_species_data.xml
+++ b/tools/ogc_services/get_species_data.xml
@@ -1,0 +1,45 @@
+<tool id="get_species_data" name="Get species data" version="0.1.0">
+    <description>Get species occurrence coordinates from GBIF, inside a river basin.</description>
+    <stdio>
+        <exit_code range="1:" />
+    </stdio>
+    <requirements>
+        <requirement type="package">geojson</requirement>
+    </requirements>
+    <command><![CDATA[
+        python $__tool_directory__/wrap_get_species_data.py --ogc_service_url $ogc_service_url --species_name "$species_name" --basin_id "$basin_id" --output $galaxy_output
+    ]]></command>
+    <inputs>
+        <param name="ogc_service_url" type="text" label="OGC API: Which URL to request, including port." value="http://localhost:5000"></param>
+        <param name="species_name" type="select" label="Which species...">
+            <option value="Conorhynchos conirostris">Conorhynchos conirostris</option>
+            <option value="Other">No other species right now</option>
+        </param>
+        <param name="basin_id" type="select" label="Which basin...">
+            <option value="481051">Basin Sao Francisco (I think)</option>
+            <option value="Other">No other basin right now</option>
+        </param>
+    </inputs>
+    <outputs>
+        <data name="galaxy_output" format="geojson" />
+    </outputs>
+    <tests>
+        <test>
+            <!--<output name="galaxy_output" file="/galaxy/tools/mytools/test_data/test_output.txt"/>-->
+        </test>
+    </tests>
+    <help><![CDATA[
+        Retrieve point coordinates from species occurrence from the GBIF database, using rgbif package. Return only the ones located in the selected river basin (filtering done using sf package).
+    ]]></help>
+    <citations>
+        <citation type="bibtex">
+            @Manual{,
+                title = {httr2: Perform HTTP Requests and Process the Responses},
+                author = {Hadley Wickham},
+                year = {2023},
+                note = {R package version 0.2.3},
+                url = {https://CRAN.R-project.org/package=httr2},
+            }
+        </citation>
+    </citations>
+</tool>

--- a/tools/ogc_services/wrap_get_species_data.py
+++ b/tools/ogc_services/wrap_get_species_data.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+
+import requests
+import argparse
+import sys
+import geojson
+import logging
+
+LOGGER = logging.getLogger(__name__)
+
+
+'''
+Merret, 16 Oktober 2023
+
+Calling this script:
+python /home/mbuurman/galaxy/galaxy/tools/ogc_services/wrap_get_species_data.py --species_name "Conorhynchos conirostris" --basin_id "481051" --output "output.json"
+
+This script is a wrapper to be called by Galaxy.
+It then makes a HTTP request to a OGC service.
+
+These are the valid inputs for the OGC service:
+{
+    "inputs":{
+        "species_name":"Conorhynchos conirostris",
+        "basin_id":"481051"
+    }
+}
+
+How to call the pygeoapi service that this script calls?
+curl -X POST "http://localhost:5000/processes/get-species-data/execution" -H "Content-Type: application/json" -d "{\"inputs\":{\"species_name\":\"Conorhynchos conirostris\",\"basin_id\":\"481051\"}}"
+'''
+
+
+if __name__ == '__main__':
+
+    print('Python script: %s' % sys.argv[0])
+
+    logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
+
+    ### Replace those weird escaped characters from the string that was passed by Galaxy GUI:
+    LOGGER.debug('Python script inputs sys.argv: %s' % sys.argv)
+    '''
+    LOGGER.debug('Run the replacement dirty fix:')
+    i = 0
+    for i in range(0,len(sys.argv)):
+        LOGGER.debug('Python command line arg: "%s"' % sys.argv[i])
+        sys.argv[i] = sys.argv[i].replace('__oc__', '{').replace('__cc__', '}')
+        sys.argv[i] = sys.argv[i].replace('__ob__', '[').replace('__cb__', ']')
+        sys.argv[i] = sys.argv[i].replace('__dq__', '"')
+        sys.argv[i] = sys.argv[i].replace('__cn__', '')
+        LOGGER.debug('Same item after replace: "%s"' % sys.argv[i])
+        # https://git.bwcloud.uni-freiburg.de/galaxyproject/galaxy/-/blob/5701fe7e108126fda05c33dfe083bd2c7f370db9/tools/filters/grep.py#L71
+    '''
+
+    ### Input params
+    ### These are provided by Galaxy (call defined in the tool's xml file.)
+    LOGGER.debug('Getting the input parameters...')
+    parser = argparse.ArgumentParser(
+                        prog='Call the process "get-species-data" from an OGC API.',
+                        description='This program returns species occurences from GBIF, filtered by the basin XYZ.')
+    parser.add_argument('--species_name', default="Conorhynchos conirostris", help='The scienfic name whose species occurence to retrieve from GBIF.')
+    parser.add_argument('--basin_id', default="481051", help='The number of the basin in which to look for species occurences.')
+    parser.add_argument('--ogc_service_url', default="http://localhost:5000", help='Which service to call, incl. http/https and port, e.g. http://localhost:5000')
+    parser.add_argument('--output', default="DUMMY", help='Galaxy needs this, but you can just put some dummy string there.')
+    args = parser.parse_args()
+    LOGGER.debug('Getting the input parameters... done.')
+
+    # TODO FEATURE: Do we have to check the species name against some taxonomy database?
+
+    ### Assemble the HTTP request
+    LOGGER.debug('Assembling the request...')
+    url = args.ogc_service_url.rstrip('/')+'/processes/get-species-data/execution'
+    LOGGER.info('This URL will be queried: %s' % url)
+    h = {'accept': 'application/json', 'Content-Type': 'application/json'}
+    body = {
+        "inputs":{
+            "species_name" : args.species_name,
+            "basin_id": args.basin_id
+        }
+    }
+    LOGGER.info('This is the request body: %s' % body)
+    LOGGER.debug('Data type of body: %s' % type(body))
+
+
+    ### Make POST request
+    LOGGER.debug('Making POST request to server:')
+    print('Making POST request to server:')
+    resp = requests.post(url, headers=h, json=body)
+    resp_json = resp.json()
+    LOGGER.info('Finished making POST request to server! Received HTTP status code: %s' % resp.status_code)
+    LOGGER.info('And this is the server\'s response: \n%s' % resp_json)
+    # Example: {'id': 'snapped_points', 'value': {'type': 'MultiPoint', 'coordinates': [['-43.595833', '-13.763611'], ['-44.885825', '-17.25355']]}}
+
+
+    ### Hand through server errors:
+    if not resp.status_code == 200:
+        err_msg = 'Tool failure! Server responded with HTTP status code %s (expected 200)' % resp.status_code
+        LOGGER.error(err_msg)
+        raise ValueError(err_msg)
+    elif (('code' in resp_json and resp_json['code'] == 'InvalidParameterValue') 
+       or ('description' in resp_json and resp_json['description'] == 'Error updating job')):
+        err_msg = 'Tool failure! Server responded with: %s' % resp_json
+        LOGGER.error(err_msg)
+        raise ValueError(err_msg)
+
+
+    ### Write to file
+    OUTPUTFILE = args.output
+    with open(OUTPUTFILE, 'w') as out:
+        geojson.dump(resp_json, out)
+        LOGGER.info('Output written to file: %s' % OUTPUTFILE)


### PR DESCRIPTION
What I did: I added a tool (config xml and python code) that calls an OGC API service. So the main processing takes place on the server that exposes an OGC API which is called by this galaxy tool.
Why: This tool will be useful for the AquaInfra galaxy instance. So far, this is dummy and only for testing.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x]  Instructions for manual testing are as follows:
* Deploy an instance of pygeoapi locally on localhost:5000, or have an URL of a pygeoapi server ready which runs the snap-to-network OGC service.
* Run the galaxy tool snap-to-network with the given default input values.
* It should return the following GeoJON: `{"id": "species_occurrences", "value": {"type": "MultiPoint", "coordinates": [[-44.885825, -17.25355], [-43.595833, -13.763611], [-45.780827, -17.178306], [-45.904444, -17.074722], [-46.893511, -17.397917], [-45.245, -18.136], [-45.24, -18.14], [-43.138889, -11.092222], [-44.954661, -17.356778], [-43.966667, -14.916667], [-44.954963, -17.336154], [-44.357, -15.49277], [-44.357, -15.492768]]}}`


## License
- []  I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).    THIS IS JUST A TEST COMMIT.

